### PR TITLE
Adding repo health state script code

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,25 @@
+Change Log
+----------
+
+..
+   All enhancements and patches to pytest-opynions will be documented
+   in this file.  It adheres to the structure of http://keepachangelog.com/ ,
+   but in reStructuredText instead of Markdown (for ease of incorporation into
+   Sphinx documentation and the PyPI description).
+   
+   This project adheres to Semantic Versioning (http://semver.org/).
+
+.. There should always be an "Unreleased" section for changes pending release.
+
+Unreleased
+~~~~~~~~~~
+
+*
+
+[0.1.0] - 2020-03-16
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Added
+_____
+
+* 

--- a/README.rst
+++ b/README.rst
@@ -18,8 +18,6 @@ pytest-opynions
     :target: https://ci.appveyor.com/project/jinder1s/pytest-opynions/branch/master
     :alt: See Build Status on AppVeyor
 
-A simple plugin to use with pytest
-
 ----
 
 This `pytest`_ plugin was generated with `Cookiecutter`_ along with `@hackebrot`_'s `cookiecutter-pytest-plugin`_ template.

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,6 @@ setup(
     author_email='msingh@edx.org',
     maintainer='Manjinder Singh',
     maintainer_email='msingh@edx.org',
-    license='MIT',
     url='https://github.com/jinder1s/pytest-opynions',
     description='A simple plugin to use with pytest',
     long_description=read('README.rst'),

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,33 @@ def read(fname):
     file_path = os.path.join(os.path.dirname(__file__), fname)
     return codecs.open(file_path, encoding='utf-8').read()
 
+def load_requirements(*requirements_paths):
+    """
+    Load all requirements from the specified requirements files.
+
+    Returns:
+        list: Requirements file relative path strings
+    """
+    requirements = set()
+    for path in requirements_paths:
+        requirements.update(
+            line.split('#')[0].strip() for line in open(path).readlines()
+            if is_requirement(line.strip())
+        )
+    return list(requirements)
+
+
+def is_requirement(line):
+    """
+    Return True if the requirement line is a package requirement.
+
+    Returns:
+        bool: True if the line is not blank, a comment, a URL, or an included file
+    """
+    return line and not line.startswith(('-r', '#', '-e', 'git+', '-c'))
+
+README = open(os.path.join(os.path.dirname(__file__), 'README.rst')).read()
+CHANGELOG = open(os.path.join(os.path.dirname(__file__), 'CHANGELOG.rst')).read()
 
 setup(
     name='pytest-opynions',
@@ -23,25 +50,22 @@ setup(
     description='A simple plugin to use with pytest',
     long_description=read('README.rst'),
     py_modules=['pytest_opynions'],
-    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
-    install_requires=['pytest>=3.5.0'],
+    python_requires=">=3.5",
+    install_requires=load_requirements('requirements/base.in'),
+    zip_safe=False,
+    keywords='Django edx',
+    license="Apache Software License 2.0",
     classifiers=[
-        'Development Status :: 4 - Beta',
-        'Framework :: Pytest',
+        'Development Status :: 3 - Alpha',
         'Intended Audience :: Developers',
+        'License :: OSI Approved :: Apache Software License',
+        'Natural Language :: English',
         'Topic :: Software Development :: Testing',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: Implementation :: CPython',
-        'Programming Language :: Python :: Implementation :: PyPy',
-        'Operating System :: OS Independent',
-        'License :: OSI Approved :: MIT License',
+        'Programming Language :: Python :: 3.8',
     ],
     entry_points={
         'pytest11': [


### PR DESCRIPTION
To run plugin code:
install plugin and pytest, goto repo that you would like to test and run: 
pytest -c <() --repo-health-check True --repo-path `pwd` --noconftest -s

Currently, output is in the form of print, but as we decided on output form, we can easily print out either a json file or csv if we want. Json file would be easier.


